### PR TITLE
Add simplecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development do
 end
 
 group :test do
+  gem 'simplecov'
   gem 'webmock'
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,11 @@ require 'bundler/setup'
 require 'pry'
 require 'webmock/rspec'
 
+require 'simplecov'
+SimpleCov.start do
+  enable_coverage :branch
+end
+
 require 'oembed_proxy'
 
 require 'support/fixture_loader'


### PR DESCRIPTION
I added this locally while reviewing. 

The Gemfile.lock is in the gitignore, which is why that's not in the changes. The coverage directory is already in the gitignore, so that didn't need to be added. 